### PR TITLE
#86 - 패시브와 DP가 멈추는 로직 구현.

### DIFF
--- a/Source/Project_IK/Private/Abilities/PassiveSkill.cpp
+++ b/Source/Project_IK/Private/Abilities/PassiveSkill.cpp
@@ -72,6 +72,16 @@ void APassiveSkill::FinishCoolDown()
 	GetWorld()->GetTimerManager().ClearTimer(cool_time_handle_);
 }
 
+void APassiveSkill::StartHoldCoolDown()
+{
+	GetWorld()->GetTimerManager().PauseTimer(cool_time_handle_);
+}
+
+void APassiveSkill::FinishHoldCoolDown()
+{
+	GetWorld()->GetTimerManager().UnPauseTimer(cool_time_handle_);
+}
+
 void APassiveSkill::StopPassiveSkill()
 {
 	if(on_passive_skill_)
@@ -122,4 +132,9 @@ void APassiveSkill::SetDuration(float Duration)
 bool APassiveSkill::IsPassiveAvailable() const
 {
 	return is_available;
+}
+
+bool APassiveSkill::IsOnPassiveSkill() const
+{
+	return on_passive_skill_;
 }

--- a/Source/Project_IK/Private/Components/DroneMechanics.cpp
+++ b/Source/Project_IK/Private/Components/DroneMechanics.cpp
@@ -18,6 +18,7 @@ See LICENSE file in the project root for full license information.
 UDroneMechanics::UDroneMechanics()
 {
 	PrimaryComponentTick.bCanEverTick = true;
+	on_jammed_ = false;
 }
 
 // Called when the game starts
@@ -35,6 +36,49 @@ void UDroneMechanics::EndPlay(const EEndPlayReason::Type EndPlayReason)
 void UDroneMechanics::Initialize(AActor* hero)
 {
 	hero_ref_ = hero;
+}
+
+void UDroneMechanics::GetJammed(float duration)
+{
+	//만약 밴된 도중에 다시 밴 된다면, 밴 시간만 조정한다.
+	if(on_jammed_)
+	{
+		GetWorld()->GetTimerManager().SetTimer(jam_time_handle_, this, &UDroneMechanics::FinishJam, duration, false);
+		return;
+	}
+
+	if(general_plugin_)
+	{
+		if(general_plugin_->IsOnPassiveSkill() || general_plugin_->IsPassiveAvailable())
+		{
+			general_plugin_->FinishPassiveSkillAndStartCoolDown();
+		}
+		general_plugin_->StartHoldCoolDown();
+	}
+	if(periodic_plugin_)
+	{
+		if(periodic_plugin_->IsOnPassiveSkill() || periodic_plugin_->IsPassiveAvailable())
+		{
+			periodic_plugin_->FinishPassiveSkillAndStartCoolDown();
+		}
+		periodic_plugin_->StartHoldCoolDown();
+	}
+	//duration동안 쿨타임이 돌지 못하게 한다.
+	GetWorld()->GetTimerManager().SetTimer(jam_time_handle_, this, &UDroneMechanics::FinishJam, duration, false);
+	on_jammed_ = true;
+}
+
+void UDroneMechanics::FinishJam()
+{
+	if(periodic_plugin_)
+	{
+		periodic_plugin_->FinishHoldCoolDown();
+	}
+	if(general_plugin_)
+	{
+		general_plugin_->FinishHoldCoolDown();
+	}
+	on_jammed_ = false;
 }
 
 float UDroneMechanics::GetPeriodicPluginHoldTime() const
@@ -91,15 +135,6 @@ void UDroneMechanics::AddPeriodicPlugIn(UClass* plugin_type)
 	}
 }
 
-void UDroneMechanics::RemovePeriodicPlugIn()
-{
-	if(periodic_plugin_ != nullptr)
-	{
-		periodic_plugin_->Destroy();
-	}
-	periodic_plugin_ = nullptr;
-}
-
 void UDroneMechanics::AddGeneralPlugIn(UClass* plugin_type)
 {
 	if(plugin_type)
@@ -118,6 +153,16 @@ void UDroneMechanics::AddGeneralPlugIn(UClass* plugin_type)
 			general_plugin_->AttachToComponent(GetOwner()->GetRootComponent(), FAttachmentTransformRules::KeepRelativeTransform);
 		}
 	}
+}
+
+
+void UDroneMechanics::RemovePeriodicPlugIn()
+{
+	if(periodic_plugin_ != nullptr)
+	{
+		periodic_plugin_->Destroy();
+	}
+	periodic_plugin_ = nullptr;
 }
 
 void UDroneMechanics::RemoveGeneralPlugIn()

--- a/Source/Project_IK/Public/Abilities/PassiveMechanics.h
+++ b/Source/Project_IK/Public/Abilities/PassiveMechanics.h
@@ -31,6 +31,8 @@ public:
 	void OnFinishHoldTime();
 	bool IsPassiveAvailable() const;
 	
+	void BanPassive(float duration);
+	
 	void OnStunned();
 	float GetHoldTime() const;
 
@@ -43,4 +45,10 @@ private:
 	
 	UPROPERTY(Transient)
 	FTimerHandle hold_time_handle_;
+
+	UPROPERTY(Transient)
+	FTimerHandle ban_time_handle_;
+
+	UPROPERTY(Transient)
+	bool on_banned_;
 };

--- a/Source/Project_IK/Public/Abilities/PassiveSkill.h
+++ b/Source/Project_IK/Public/Abilities/PassiveSkill.h
@@ -28,6 +28,9 @@ public:
 	virtual void StartPassiveSkill();
 	virtual void FinishPassiveSkillAndStartCoolDown();
 	virtual void FinishCoolDown();
+	virtual void StartHoldCoolDown();
+	virtual void FinishHoldCoolDown();
+
 
 	void StopPassiveSkill();
 
@@ -47,6 +50,7 @@ public:
 	float GetHoldTime() const;
 	void SetHoldTime(float Hold_Time);
 	bool IsPassiveAvailable() const;
+	bool IsOnPassiveSkill() const;
 	
 protected:
 	UPROPERTY(EditDefaultsOnly, BlueprintReadWrite, Category = "PassiveSkill", meta = (AllowPrivateAccess = "true"))

--- a/Source/Project_IK/Public/Components/DroneMechanics.h
+++ b/Source/Project_IK/Public/Components/DroneMechanics.h
@@ -31,6 +31,8 @@ protected:
 public:	
 	// Called every frame
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+	void GetJammed(float duration);
+	void FinishJam();
 
 	//AI에서 Periodic plugin을 control하기 위한 함수들.
 	float GetPeriodicPluginHoldTime() const;
@@ -56,4 +58,10 @@ private:
 
 	UPROPERTY(Transient)
 	FTimerHandle hold_time_handle_;
+
+	UPROPERTY(Transient)
+	FTimerHandle jam_time_handle_;
+
+	UPROPERTY(Transient)
+	bool on_jammed_;
 };

--- a/Source/Project_IK/Public/Managers/EnumCluster.h
+++ b/Source/Project_IK/Public/Managers/EnumCluster.h
@@ -38,10 +38,10 @@ UENUM(BlueprintType)
 enum class EDroneState  : uint8
 {
 	Idle UMETA(DisplayName = "Idle"),
+	BannedDP UMETA(DisplayName = "BannedDP"),
 	UsingPeriodicDP UMETA(DisplayName = "UsingPeriodicDP"),
 	UsingGeneralDP UMETA(DisplayName = "UsingGeneralDP")
 };
-
 
 UENUM(BlueprintType)
 enum class ECCType : uint8


### PR DESCRIPTION
DroneMechanics의 GetJammed함수와 PassiveMechanics의 BanPassive함수를 통해 패시브와 DP를 사용하지 못하는 로직을 구현하였다.

DP를 예시로 들면 로직은 다음과 같다.
GetJammed 함수를 호출하면, 먼저 현재 DP가 실행 중인지 확인한다.
만약 실행 중이라면 실행을 중지하고, 쿨타임을 기다리는 단계로 넘어간다.
만약 쿨타임을 기다리고 있다면 그대로 진행한다.

그리고 인자로 들어온 시간 동안 쿨타임이 흐르지 않게 하여 패시브, 또는 DP를 사용하지 못하게 한다.

로직 자체는 구현 되었지만, 아직 테스트 해볼 적절한 수단이 없어 테스트를 해보지 못했다.